### PR TITLE
docs: progressive disclosure refactor for CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,30 +1,18 @@
 # CLAUDE.md
 
-## Project
+TypeScript web app showcasing JavaScript Set composition methods with Venn diagram visualizations. TypeScript + Vite, no framework — intentionally kept simple.
 
-Interactive web app showcasing JavaScript Set composition methods with visual Venn diagrams. Vanilla JS, no framework — intentionally kept simple.
+## Commands
 
-## Code Conventions
-
-- Factory pattern: `create*()` functions returning objects with public methods
-- Event-driven architecture via `eventBus` (pub/sub)
-- Dependency injection — functions accept deps as params
-- Thin adapter modules (contentRenderer, diagramRendererService, focusManager, selectionStateManager) wrap single operations for DI; they have no business logic and are intentionally untested
-- No ESLint/Prettier — uses `.editorconfig` only
-
-## Architecture
-
-- `renderOrchestrator` coordinates the render flow across UI modules
-- `diagramStrategies` uses strategy pattern for Venn diagram SVGs
-- Hash-based routing (no library) via `navigationManager` + `urlManager`
-- Accessibility: ARIA attributes, semantic HTML, skip links
+- Typecheck: `npm run typecheck`
+- Test (single pass): `npm run test:run`
+- Test (watch): `npm test`
 
 ## Commits
 
 Follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).
 
-## Testing
+## Docs
 
-- Tests in `js/test/` mirror source structure
-- Test config: `js/test/vitest.config.js` (jsdom environment, globals enabled)
-- Run `npm run test:run` for single pass, `npm test` for watch mode
+- [Architecture & Patterns](docs/agents/architecture.md)
+- [Testing](docs/agents/testing.md)

--- a/docs/agents/architecture.md
+++ b/docs/agents/architecture.md
@@ -1,0 +1,20 @@
+# Architecture & Patterns
+
+## Patterns
+
+- Factory: `create*()` functions return objects with public methods
+- Event-driven: `eventBus` pub/sub
+- DI: functions accept deps as params
+- Strategy: `diagramStrategies` for Venn diagram SVGs
+- Adapters: `contentRenderer`, `diagramRendererService`, `focusManager`,
+  `selectionStateManager` — wrap single operations for DI; no business logic,
+  intentionally untested
+
+## Module Map
+
+- `renderOrchestrator` coordinates the render flow across UI modules
+- Hash-based routing via `navigationManager` + `urlManager`
+
+## Tooling
+
+- No ESLint/Prettier — uses `.editorconfig` only

--- a/docs/agents/testing.md
+++ b/docs/agents/testing.md
@@ -1,0 +1,4 @@
+# Testing
+
+- Tests in `js/test/` mirror source structure
+- Config: `js/test/vitest.config.ts` (jsdom, globals enabled)


### PR DESCRIPTION
## Summary

- Rewrites `CLAUDE.md` as a minimal root with links to topic sub-docs
- Adds `docs/agents/architecture.md` (patterns + module map)
- Adds `docs/agents/testing.md` (test structure)
- Fixes "Vanilla JS" → "TypeScript + Vite"

🤖 Generated with [Claude Code](https://claude.com/claude-code)